### PR TITLE
Load scripts in parallel instead of sequentially

### DIFF
--- a/vendor/embed.js
+++ b/vendor/embed.js
@@ -21,6 +21,9 @@
       if (script.content) {
         scriptTag.textContent = script.content;
       }
+      scriptTag.defer = true;
+      scriptTag.async = false;
+
       head.appendChild(scriptTag);
       if (!hasSrc) {
         resolve();
@@ -29,9 +32,9 @@
   }
 
   async function injectScripts(scripts, head, host) {
-    for (let script of scripts) {
-      await injectScript(script, head, host);
-    }
+    await Promise.all(
+      scripts.map((script) => injectScript(script, head, host))
+    );
   }
 
   function injectLinks(links, head, host) {


### PR DESCRIPTION
To run scripts in the right order, currently we are loading them sequentially by hand (by waiting for their load event). By injecting scripts all at once, but using `defer`, we keep the execution order in place (important!), while still allowing parallelization of network requests.