### PR TITLE
Don't call customElements.define if definition already exists

### DIFF
--- a/vendor/embed.js
+++ b/vendor/embed.js
@@ -160,5 +160,9 @@
     }
   }
 
-  customElements.define('###CENAME###', EmbeddedApp);
+  let definition = customElements.get('###CENAME###');
+
+  if (definition == null) {
+    customElements.define('###CENAME###', EmbeddedApp);
+  }
 })();


### PR DESCRIPTION
This guards against defining a Custom Element if it has already been defined previously. Without this, instantiating the app multiple times throws an error: `Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "my-app" has already been used with this registry`.

Our use case is that we embed an Ember app in a parent app under a certain route. When navigating between different routes in the parent app, a user can enter the Ember app, go to a different route, then go back to the Ember app. Each time the Ember app renders, `ember-embedded-snippet` tries to define the Custom Element.

Unfortunately it is not possible to unregister a Custom Element, so the only way to avoid throwing the error is to check if a definition already exists and not do anything if that's the case.